### PR TITLE
19.09 reproducer

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -9,7 +9,7 @@ extern "C" {
 #include "algebra.hh"
 #include "types.hh"
 
-void initialize(std::string const & filename, prMatrix_t M,
+void initialize(Index_t nodelet, std::string const & filename, prMatrix_t M,
                 Index_t const nnodes, Index_t const nedges)
 {
     Index_t tmp;
@@ -37,7 +37,7 @@ void initialize(std::string const & filename, prMatrix_t M,
     {
         Index_t i = iL[e];
         Index_t j = jL[e];
-        if (n_map(i) == NODE_ID())
+        if (n_map(i) == nodelet)
         {
             iL_nl.push_back(i);
             jL_nl.push_back(j);
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
     for (Index_t i = 0; i < NODELETS(); ++i)
     {
         cilk_migrate_hint(L->row_addr(i));
-        cilk_spawn initialize(filename, L, nnodes, nedges);
+        cilk_spawn initialize(i, filename, L, nnodes, nedges);
     }
     cilk_sync;
 

--- a/types.hh
+++ b/types.hh
@@ -133,7 +133,7 @@ private:
         else // insert into row
         {
             Row_t::iterator it = r->begin();
-            while (std::get<0>(*it) < icol and it != r->end())
+            while (it != r->end() and std::get<0>(*it) < icol)
             {
                 ++it;
             }


### PR DESCRIPTION
Workaround for https://github.com/emusolutions/emu-issue-tracking/issues/67. 

As a general rule, the correct execution of a program should not rely on a particular thread migration pattern. Small changes to the code or the toolchain often introduce or remove spurious migrations.                                                                                                                                                                                                                                                                                                                                                                                      This applies even when using `cilk_migrate_hint`. The return value of `NODE_ID()` may change unpredictably when function calls and stack spills are present.

In this case, the threads of `initialize` were always on nodelet 0 when they called `NODE_ID()`, so all the threads were trying to append to rows at the same time, leading to memory errors. I don't have a good explanation for why this happens v19.09 but not v19.02. as far as I can tell the thread ought to have no reason to return home. Will investigate further.

Separately, fixed a read past the end of an iteration space. This is what valgrind/AddressSanitizer were picking up on, but probably not related to the crash. 
